### PR TITLE
docs(build): remove cargo after build success

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,3 +29,6 @@ RUN cargo build \
     && python3 setup.py install --user \
     && cd examples \
     && cargo run --example run_with_plugins -- -p logical_test
+
+RUN cargo build --example run_with_plugins --release \
+    && ln -s ../../target/release/examples/run_with_plugins

--- a/docs/FAQ.zh.md
+++ b/docs/FAQ.zh.md
@@ -7,7 +7,7 @@ A：如果使用 conda 只需要
 $ export LD_LIBRARY_PATH=`conda info --base`/pkgs/python-3.8.11-xxx/lib:${LD_LIBRARY_PATH}
 ```
 ___
-Q：`cargo run --example run_with_plugins -- -p logical_test ` 无法运行怎么办？
+Q：`run_with_plugins -p logical_test ` 无法运行怎么办？
 
 A1：如果报错 `message: "No such file or directory" }'`，确认是否`cd flow-python/examples`
 

--- a/docs/how-to-add-my-service/01-single-classification-model.zh.md
+++ b/docs/how-to-add-my-service/01-single-classification-model.zh.md
@@ -132,7 +132,7 @@ class Classify:
 运行服务
 ```bash
 $ cd flow-python/examples
-$ cargo run --example run_with_plugins -- -c simple_classification/image_cpu.toml  -p  simple_classification # 源码/docker 编译方式用这条命令
+$ run_with_plugins -c simple_classification/image_cpu.toml  -p  simple_classification # 源码/docker 编译方式用这条命令
 ```
 
 浏览器打开 8084 端口服务（例如 http://10.122.101.175:8084/docs ），选择一张图“try it out”即可。

--- a/docs/how-to-build-and-run/build-from-source.zh.md
+++ b/docs/how-to-build-and-run/build-from-source.zh.md
@@ -79,9 +79,16 @@ P.S. 默认 ffmpeg 依赖自动从 github 上拉取源码构建，这会使得�
 ## 三、Python“开机自检”
 ```bash
 $ cd examples
-$ cargo run --example run_with_plugins -- -p logical_test
+$ cargo build --example run_with_plugins --release # 编译出 megflow bin
+$ ln -s ../../target/example/run_with_plugins
+$ ./run_with_plugins -p logical_test
 ```
 `logical_test` 是 examples 下最基础的计算图测试用例，运行能正常结束表示 MegFlow 编译成功、基本语义无问题。
+
+`run_with_plugins` 是计算图的实现。编译完成之后不再需要 `cargo` 和 `Rust`，使用者只需要
+
+  * `import megflow`成功
+  * `run_with_plugins -h` 正常
 
 
 ## 四、Python Built-in Applications

--- a/docs/how-to-build-and-run/run-in-15-minutes.zh.md
+++ b/docs/how-to-build-and-run/run-in-15-minutes.zh.md
@@ -37,12 +37,12 @@ Python 3.8.3 (default, May 19 2020, 18:47:26)
 Type "help", "copyright", "credits" or "license" for more information.
 >>> import megflow
 ```
-.whl 打包了可执行文件 `run_with_plugins`，如果使用 conda 位置应该在
+
+.whl 提供了 `run_with_plugins`命令，某些环境可能要`export PATH=~/.local/bin/:${PATH}`
+
 ```bash
-$ cd ${HOME}/miniconda3/envs/py38/lib/python3.8/site-packages/megflow/
-$ sudo apt install build-essential -y
-$ ldd run_with_plugins         # 可看到仅依赖常见库
-$ ./run_with_plugins --help
+$ apt install build-essential -y
+$ run_with_plugins -h
 run_with_plugins 1.0
 megvii
 ...
@@ -61,6 +61,10 @@ $ run_with_plugins -p logical_test
 ```bash
 $ export LD_LIBRARY_PATH=`conda info --base`/pkgs/python-3.8.11-xxx/lib:${LD_LIBRARY_PATH}
 ```
+`run_with_plugins` 是计算图的实现。使用者不需要关心 Rust/cargo，只需要
+
+  * `import megflow` 成功
+  * `run_with_plugins -h` 正常
 
 > 工作原理：[megflow](../../flow-python/megflow/__init__.py) 仅是一层接口，由 run_with_plugins “注入”建图/调度/优化等实现。
 

--- a/flow-python/examples/cat_finder/README.md
+++ b/flow-python/examples/cat_finder/README.md
@@ -46,14 +46,16 @@ $ python3
 '1.6.0'
 ```
 
+**此处 30xx 卡常见问题**：Ampere 架构的卡安装 megengine，需要看这个 [issue](https://github.com/MegEngine/MegEngine/issues/212)。解决 30xx 强依赖 cuda11 而 mge 又无法分发（EAR 约束）的问题。
+
 ## 四、图片注册
 
 启动图片服务
 ```bash
 $ cd flow-python/examples
 $ pip3 install -r requires.txt
-$ cargo run --example run_with_plugins -- -c cat_finder/image_gpu.toml  -p cat_finder    # 有 GPU 的机器执行这个
-$ cargo run --example run_with_plugins -- -c cat_finder/image_cpu.toml  -p cat_finder    # 无 GPU 的 laptop 执行这句
+$ run_with_plugins -c cat_finder/image_gpu.toml  -p cat_finder    # 有 GPU 的机器执行这个
+$ run_with_plugins -c cat_finder/image_cpu.toml  -p cat_finder    # 无 GPU 的 laptop 执行这句
 ```
 
 **此处常见问题**：`error while loading shared libraries: libpython3.8.xxx`，意为 libpython.so 找不到。如果使用 conda 就在 miniconda 安装目录下面，只需要设置环境变量
@@ -114,8 +116,8 @@ $ ffmpeg -re -stream_loop -1 -i ${models}/cat_finder_testdata/test1.ts -c copy -
 启动视频识别服务
 ```bash
 $ cd flow-python/examples
-$ cargo run --example run_with_plugins -- -c cat_finder/video_gpu.toml  -p cat_finder  # 有 GPU 的机器
-$ cargo run --example run_with_plugins -- -c cat_finder/video_cpu.toml  -p cat_finder  # 无 GPU 的设备用这句
+$ run_with_plugins -c cat_finder/video_gpu.toml  -p cat_finder  # 有 GPU 的机器
+$ run_with_plugins -c cat_finder/video_cpu.toml  -p cat_finder  # 无 GPU 的设备用这句
 ```
 打开 8082 端口服务（如 http://127.0.0.1:8082/docs ）。
 

--- a/flow-python/examples/electric_bicycle/README.md
+++ b/flow-python/examples/electric_bicycle/README.md
@@ -40,7 +40,7 @@ $ pip3 install onnxruntime --user
 启动服务
 ```bash
 $ cd flow-python/examples
-$ cargo run --example run_with_plugins -- -c electric_bicycle/electric_bicycle.toml  -p electric_bicycle
+$ run_with_plugins -c electric_bicycle/electric_bicycle.toml  -p electric_bicycle
 ```
 服务配置文件在`electric_bicycle/electric_bicycle.toml`，解释参考 [how-to-add-graph](../../../docs/how-to-add-my-service/01-single-classification-model.zh.md) 。这里只需要打开 8083 端口服务，操作和[猫猫围栏](../cat_finder/README.md) 近似。
 


### PR DESCRIPTION
* build 之后的文档，不再提 cargo run 防止误解
* 对 30xx 系列的卡，需要说明应该怎么搞
* 有些用户 whl 安装后没有 run_with_plugins ，需要 export PATH=\~/.local/bin:${PATH}